### PR TITLE
Fix version conflicts caused by PR#44

### DIFF
--- a/Maxisoft.Utils.Tests/Maxisoft.Utils.Tests.csproj
+++ b/Maxisoft.Utils.Tests/Maxisoft.Utils.Tests.csproj
@@ -5,9 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.14.0" />
-    <PackageReference Include="AutoFixture.SeedExtensions" Version="4.14.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.SeedExtensions" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump AutoFixture.Xunit2 from 4.14.0 to 4.17.0. [(PR#44)](https://github.com/maxisoft/Maxisoft.Utils/pull/44).
Hope this fix can help you.

Best regards,
sucrose